### PR TITLE
Add the Xcode 12 option Build Active Scheme for Playgrounds, which is enabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Package.pins
 Package.resolved
 /*.xcodeproj
+/.swiftpm

--- a/Sources/Playground.swift
+++ b/Sources/Playground.swift
@@ -22,6 +22,8 @@ public class Playground: Generatable {
     public var platform: Platform
     /// Whether the playground should be automatically run on each code change
     public var autoRun: Bool
+    /// Whether the playground should build the packages or frameworks for import into the playground
+    public var buildActiveScheme: Bool
     /// The code that the playground should contain (if nil, a default will be used)
     public var code: String?
     /// The auxiliary source files that the playground should include
@@ -41,13 +43,14 @@ public class Playground: Generatable {
      *  Note that you have to call `generate()` on the playground to actually
      *  generate it on the file system.
      */
-    public init(path: String, platform: Platform = .iOS, autoRun: Bool = true, code: String? = nil) {
+    public init(path: String, platform: Platform = .iOS, autoRun: Bool = true, buildActiveScheme: Bool = true, code: String? = nil) {
         self.path = path.removingSuffixIfNeeded("/")
                         .addingSuffixIfNeeded(".playground")
                         .appending("/")
 
         self.platform = platform
         self.autoRun = autoRun
+        self.buildActiveScheme = buildActiveScheme
         self.code = code
     }
 
@@ -77,7 +80,7 @@ public class Playground: Generatable {
 
     private func generateXML() -> String {
         var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
-        xml.append("<playground version=\"5.0\" target-platform=\"\(platform.rawValue)\" executeOnSourceChanges=\"\(autoRun)\">")
+        xml.append("<playground version=\"5.0\" target-platform=\"\(platform.rawValue)\" executeOnSourceChanges=\"\(autoRun)\" buildActiveScheme='\(buildActiveScheme)'>")
         xml.append("    <timeline fileName=\"timeline.xctimeline\"/>")
         xml.append("</playground>")
         return xml

--- a/Tests/XgenTests/XgenTests.swift
+++ b/Tests/XgenTests/XgenTests.swift
@@ -103,6 +103,11 @@ class XgenTests: XCTestCase {
         let playground = Playground(path: folder.path)
         XCTAssertTrue(playground.autoRun)
     }
+    
+    func testPlaygroundBuildsActiveSchemeByDefault() {
+        let playground = Playground(path: folder.path)
+        XCTAssertTrue(playground.buildActiveScheme)
+    }
 
     func testGeneratingPlaygroundWithoutAutoRun() throws {
         let playground = Playground(path: folder.path + "Playground", autoRun: false)
@@ -115,6 +120,19 @@ class XgenTests: XCTestCase {
         let xml = try XMLDocument(data: contentsFile.read(), options: [])
         let autoRunAttribute = xml.rootElement()?.attribute(forName: "executeOnSourceChanges")
         XCTAssertEqual(autoRunAttribute?.stringValue, "false")
+    }
+    
+    func testGeneratingPlaygroundWithoutBuildActiveScheme() throws {
+        let playground = Playground(path: folder.path + "Playground", buildActiveScheme: false)
+        XCTAssertFalse(playground.buildActiveScheme)
+
+        try playground.generate()
+
+        let playgroundFolder = try folder.subfolder(named: "Playground.playground")
+        let contentsFile = try playgroundFolder.file(named: "contents.xcplayground")
+        let xml = try XMLDocument(data: contentsFile.read(), options: [])
+        let buildActiveSchemeAttribute = xml.rootElement()?.attribute(forName: "buildActiveScheme")
+        XCTAssertEqual(buildActiveSchemeAttribute?.stringValue, "false")
     }
 
     func testPlaygroundWithoutAuxiliarySourceFilesDoesNotHaveSourcesFolder() throws {


### PR DESCRIPTION
This PR adds the playground attribute `buildActiveScheme`, which was introduced in Xcode 12. It is enabled by default, which matches the Xcode 12 default for new playgrounds.